### PR TITLE
Auto increment version for `lr_trie`

### DIFF
--- a/lr_trie/src/absorb_op.rs
+++ b/lr_trie/src/absorb_op.rs
@@ -6,6 +6,7 @@ use patriecia::{
 };
 use tracing::error;
 
+/// The number by which the [`Version`] of a [`JellyfishMerkleTree`] is incremented.
 const INCREMENT_ARG: u64 = 1;
 
 impl<D, H> Absorb<Operation> for JellyfishMerkleTree<D, H>

--- a/lr_trie/src/absorb_op.rs
+++ b/lr_trie/src/absorb_op.rs
@@ -17,9 +17,9 @@ where
     fn absorb_first(&mut self, operation: &mut Operation, _other: &Self) {
         // TODO: the unwrap_or_default avoids panic but is not logically sound and should
         // not be used in production since `Version` is monotonically increasing and could
-        // eventually overflow. Instead, we should consider another solution. Possibly by
-        // creating a recursive tree where the version overflow results in the first version
-        // of a new tree, we can avoid this scenario. cc @nopestack
+        // eventually overflow.
+        //
+        // cc @nopestack
         let increment_version =
             |vers: &mut u64| vers.checked_add(INCREMENT_ARG).unwrap_or_default();
         match operation {

--- a/lr_trie/src/absorb_op.rs
+++ b/lr_trie/src/absorb_op.rs
@@ -1,3 +1,4 @@
+use crate::Operation;
 use left_right::Absorb;
 pub use left_right::ReadHandleFactory;
 use patriecia::{
@@ -5,7 +6,7 @@ use patriecia::{
 };
 use tracing::error;
 
-use crate::Operation;
+const INCREMENT_ARG: u64 = 1;
 
 impl<D, H> Absorb<Operation> for JellyfishMerkleTree<D, H>
 where
@@ -13,10 +14,17 @@ where
     H: SimpleHasher,
 {
     fn absorb_first(&mut self, operation: &mut Operation, _other: &Self) {
+        // TODO: the unwrap_or_default avoids panic but is not logically sound and should
+        // not be used in production since `Version` is monotonically increasing and could
+        // eventually overflow. Instead, we should consider another solution. Possibly by
+        // creating a recursive tree where the version overflow results in the first version
+        // of a new tree, we can avoid this scenario. cc @nopestack
+        let increment_version =
+            |vers: &mut u64| vers.checked_add(INCREMENT_ARG).unwrap_or_default();
         match operation {
             // TODO: report errors via instrumentation
             Operation::Add(key_val, vers) => {
-                match self.put_value_set(vec![key_val.to_owned()], *vers + 1) {
+                match self.put_value_set(vec![key_val.to_owned()], increment_version(vers)) {
                     Ok((_, batch)) => {
                         if let Err(err) = self.reader().write_node_batch(&batch.node_batch) {
                             error!("Operation::Add failed to write changes to database: {err}")
@@ -25,23 +33,26 @@ where
                     Err(err) => error!("Operation::Add failed to insert key: {err}"),
                 }
             }
-            Operation::Remove(key, vers) => match self.put_value_set(vec![(*key, None)], *vers + 1)
-            {
-                Ok((_, batch)) => {
-                    if let Err(err) = self.reader().write_node_batch(&batch.node_batch) {
-                        error!("Operation::Remove failed to write changes to database: {err}")
+            Operation::Remove(key, vers) => {
+                match self.put_value_set(vec![(*key, None)], increment_version(vers)) {
+                    Ok((_, batch)) => {
+                        if let Err(err) = self.reader().write_node_batch(&batch.node_batch) {
+                            error!("Operation::Remove failed to write changes to database: {err}")
+                        }
                     }
+                    Err(err) => error!("Operation::Remove failed to remove value for key: {err}"),
                 }
-                Err(err) => error!("Operation::Remove failed to remove value for key: {err}"),
-            },
-            Operation::Extend(kvs, vers) => match self.put_value_set(kvs.to_vec(), *vers + 1) {
-                Ok((_, batch)) => {
-                    if let Err(err) = self.reader().write_node_batch(&batch.node_batch) {
-                        error!("Operation::Extend failed to write changes to database: {err}")
+            }
+            Operation::Extend(kvs, vers) => {
+                match self.put_value_set(kvs.to_vec(), increment_version(vers)) {
+                    Ok((_, batch)) => {
+                        if let Err(err) = self.reader().write_node_batch(&batch.node_batch) {
+                            error!("Operation::Extend failed to write changes to database: {err}")
+                        }
                     }
+                    Err(err) => error!("Operation::Extend failed batch update: {err}"),
                 }
-                Err(err) => error!("Operation::Extend failed batch update: {err}"),
-            },
+            }
         }
     }
 

--- a/lr_trie/src/absorb_op.rs
+++ b/lr_trie/src/absorb_op.rs
@@ -16,7 +16,7 @@ where
         match operation {
             // TODO: report errors via instrumentation
             Operation::Add(key_val, vers) => {
-                match self.put_value_set(vec![key_val.to_owned()], *vers) {
+                match self.put_value_set(vec![key_val.to_owned()], *vers + 1) {
                     Ok((_, batch)) => {
                         if let Err(err) = self.reader().write_node_batch(&batch.node_batch) {
                             error!("Operation::Add failed to write changes to database: {err}")
@@ -25,7 +25,8 @@ where
                     Err(err) => error!("Operation::Add failed to insert key: {err}"),
                 }
             }
-            Operation::Remove(key, vers) => match self.put_value_set(vec![(*key, None)], *vers) {
+            Operation::Remove(key, vers) => match self.put_value_set(vec![(*key, None)], *vers + 1)
+            {
                 Ok((_, batch)) => {
                     if let Err(err) = self.reader().write_node_batch(&batch.node_batch) {
                         error!("Operation::Remove failed to write changes to database: {err}")
@@ -33,7 +34,7 @@ where
                 }
                 Err(err) => error!("Operation::Remove failed to remove value for key: {err}"),
             },
-            Operation::Extend(kvs, vers) => match self.put_value_set(kvs.to_vec(), *vers) {
+            Operation::Extend(kvs, vers) => match self.put_value_set(kvs.to_vec(), *vers + 1) {
                 Ok((_, batch)) => {
                     if let Err(err) = self.reader().write_node_batch(&batch.node_batch) {
                         error!("Operation::Extend failed to write changes to database: {err}")

--- a/lr_trie/src/tree_wrapper.rs
+++ b/lr_trie/src/tree_wrapper.rs
@@ -209,15 +209,13 @@ mod tests {
 
         let key = "Ada Lovelace";
         let value = "Analytical Engine";
-        let mut version = 1;
 
         wrapper.insert(key, value).unwrap();
-        let contains_key = wrapper.contains(&key, version).unwrap();
+        let contains_key = wrapper.contains(&key, 1).unwrap();
         assert!(contains_key);
 
-        version += 1; // update version when adding or removing
         wrapper.remove(key).unwrap();
-        let contains_key = wrapper.contains(&key, version).unwrap();
+        let contains_key = wrapper.contains(&key, 2).unwrap();
         assert!(!contains_key);
 
         assert_eq!(

--- a/lr_trie/src/trie.rs
+++ b/lr_trie/src/trie.rs
@@ -144,8 +144,7 @@ where
         self.write_handle
             .append(Operation::Add(
                 (keyhash, Some(owned_value)),
-                self.version()
-                    .expect("could not retrieve version from trie"),
+                self.version().unwrap_or_default(),
             ))
             .publish();
     }
@@ -170,8 +169,7 @@ where
         self.write_handle
             .append(Operation::Extend(
                 mapped,
-                self.version()
-                    .expect("could not retrieve version from trie"),
+                self.version().unwrap_or_default(),
             ))
             .publish();
     }


### PR DESCRIPTION
adds auto incrementalism of version each time the tree is updated, this avoids us needing to do this else where causing possible bugs or unintended behaviour or usage of the library